### PR TITLE
update javadoc extension to v0.0.2; new configuration format, search …

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -8,6 +8,7 @@ content:
     branches: HEAD
     start_path: home
   - url: https://github.com/MorphiaOrg/morphia
+#  - url: ./../morphia
     branches: [ 2.1.x, 2.0.x, 1.6.x, master ]
     start_path: docs
   - url: https://github.com/MorphiaOrg/critter
@@ -35,4 +36,25 @@ extensions:
     config:
       extract: body
       layout: javadoc
-
+      components:
+        - name: morphia
+          version: '*,!1.6'
+          sources:
+            - url: https://github.com/MorphiaOrg/morphia/releases/download/r{version}.0/morphia-core-{version}.0-javadoc.jar
+              module: javadoc
+        - name: morphia
+          version: '1.6'
+          sources:
+#            - url: https://github.com/MorphiaOrg/morphia/releases/download/r1.6.1/morphia-core-1.6.1-javadoc.jar
+            - url: https://search.maven.org/remotecontent?filepath=dev/morphia/morphia/core/1.6.1/core-1.6.1-javadoc.jar
+              module: javadoc
+        - name: morphia
+          version: '2.0'
+          sources:
+            - url: https://github.com/MorphiaOrg/morphia/releases/download/r2.0.2/morphia-core-2.0.2-javadoc.jar
+              module: javadoc
+        - name: morphia
+          version: '2.2'
+          sources:
+            - url: https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=dev.morphia.morphia&a=morphia-core&v=2.2.0-SNAPSHOT&c=javadoc
+              module: javadoc

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "local-build": "antora --generator @djencks/site-generator-default local-antora-playbook.yml --stacktrace --fetch"
   },
   "devDependencies": {
-    "@djencks/antora-javadoc": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-antora-javadoc-v0.0.1.tgz",
-    "@djencks/javadoc-ui": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-javadoc-ui-v0.0.1.tgz",
+    "@djencks/antora-javadoc": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-antora-javadoc-v0.0.2.tgz",
+    "@djencks/javadoc-ui": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-javadoc-ui-v0.0.2.tgz",
     "@djencks/playbook-builder": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-playbook-builder-v2.3.3.tgz",
     "@djencks/content-aggregator": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-content-aggregator-v2.3.3.tgz",
     "@djencks/site-generator-default": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-site-generator-default-v2.3.3.tgz",


### PR DESCRIPTION
…works, ui tweaks

Search now works!
The configuration format is quite altered, and there's an option to put all the configuration in the playbook, which I've used here.  I'll make another PR for docs master showing the config in a component descriptor.

- you can use the sonatype rest API to fetch the latest 2.2.0-SNAPSHOT javadoc jar directly.
- (I think this was your idea) In the playbook you can now specify, for a specific component name, a glob pattern for the version.  The concrete version matches will be substituted into the sources url replacing `{version}` with the actual version.  However, due to some changes you've made, this currently only works for 2.1[.0]. Perhaps you could set up redirects or just copies from something including the component version to  the latest micro version javadoc jar? 
e.g. `https://github.com/MorphiaOrg/morphia/releases/download/r2.0-LATEST/morphia-core-2.0-LATEST-javadoc.jar` points to the 2.0.2 jar. Since these are releases this doesn't look very plausible. Can you think of some way of getting from the minor version to the latest micro version? Maybe the sonatype rest api can do it, I haven't investigated.
- The only problem I know of in the UI is that the page version selector (top right) when expanded goes under the javadoc top header. This seems to be related to the `position: fixed` of the javadoc header element and the z-indexes.  I read up on stacking contexts and z-index and tried a few things but the results didn't change and didn't seem to agree with the documentation.  Do you know how to fix this?